### PR TITLE
Remove margin property that causes crashes

### DIFF
--- a/devbar@ludvigbostrom/prefs.js
+++ b/devbar@ludvigbostrom/prefs.js
@@ -25,7 +25,6 @@ function buildPrefsWidget() {
 
     // Create a parent widget that we'll return from this function
     let prefsWidget = new Gtk.Grid({
-        margin: 18,
         column_spacing: 12,
         row_spacing: 12,
         column_homogeneous: false,


### PR DESCRIPTION
Remove the `margin` property that causes crashes detailed on #1.

New Settings window looks like this: 
![image](https://user-images.githubusercontent.com/3715874/144634829-95fb6777-6cd3-425c-8eb6-699911c3c177.png)
